### PR TITLE
[DOCU] dbscript - func_log.error_msg field added

### DIFF
--- a/dbscript.sql
+++ b/dbscript.sql
@@ -39,6 +39,7 @@ CREATE TABLE func_log (
 	user_idx INTEGER NOT NULL, -- 사용자 고유번호
 	func_code VARCHAR(255) NOT NULL, -- 함수 기능 코드
 	is_worked bool NOT NULL, -- 정상 작동 여부
+	error_msg TEXT NOT NULL DEFAULT '', -- Unexpected Error일 경우 저장되는 에러 메시지
 	start_time TIMESTAMP NOT NULL, -- 작동 시작 시각
 	end_time TIMESTAMP NOT NULL, -- 작동 종료 시각
 	created_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW() -- 생성 시점
@@ -50,6 +51,7 @@ COMMENT ON TABLE func_log IS '사용자 서비스 이용시간 + 기능별 사�
 COMMENT ON COLUMN func_log.user_idx IS '사용자 고유번호';
 COMMENT ON COLUMN func_log.func_code IS '함수 기능 코드';
 COMMENT ON COLUMN func_log.is_worked IS '정상 작동 여부';
+COMMENT ON COLUMN func_log.error_msg IS 'Unexpected Error(is_worked=2)일 경우 저장되는 에러 메시지';
 COMMENT ON COLUMN func_log.start_time IS '작동 시작 시각';
 COMMENT ON COLUMN func_log.end_time IS '작동 종료 시각';
 COMMENT ON COLUMN func_log.created_time IS '생성 시점';


### PR DESCRIPTION
### 작성자
안경호

### 1. 문서화 내용
dbscript - func_log.error_msg field added

func_log 테이블에 들어가는 데이터 중 사전에 대비하지 못한 에러가 발생한 경우(is_worked=2), 해당 에러의 Traceback을 담을 컬럼(error_msg) 추가함.

NOT NULL이며 기본값은 빈 스트링('')으로 지정하였음.
